### PR TITLE
fix([local]): configure next-intl's SSG

### DIFF
--- a/app/[locale]/(client)/(home)/page.tsx
+++ b/app/[locale]/(client)/(home)/page.tsx
@@ -66,6 +66,7 @@ export default async function Home({
   params: Promise<{ locale: string }>;
 }) {
   const locale = (await params).locale;
+  // NOTE: do not remove it, it is a double check to ensure SSG is enabled
   setRequestLocale(locale);
   const siteInfo = await getSiteInfo();
   if (!siteInfo.data) {
@@ -75,8 +76,6 @@ export default async function Home({
   const siteInfoData = siteInfo.data;
   const localizedSiteInfo = siteInfoData[localeName];
   const contactData = siteInfoData.contact;
-
-  console.log(siteInfoData);
 
   return (
     <div className="min-h-screen">

--- a/app/[locale]/(client)/(pages)/about/page.tsx
+++ b/app/[locale]/(client)/(pages)/about/page.tsx
@@ -14,6 +14,7 @@ import { Metadata } from "next";
 import { setRequestLocale, getTranslations } from "next-intl/server";
 import Image from "next/image";
 
+// export const dynamic = 'force-static'
 export const revalidate = 2592000;
 
 const { PREVIEW } = PAGES_ROUTES.ABOUT;
@@ -35,12 +36,12 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { locale } = await params;
 
-  const t = await getTranslations({locale, namespace: "Metadata.about"});
+  const t = await getTranslations({ locale, namespace: "Metadata.about" });
   const title = t("title");
   const description = t("description");
   const ogTitle = t("ogTitle");
   const ogDescription = t("ogDescription");
-  const tFaq = await getTranslations("AboutPage.faq");
+  const tFaq = await getTranslations({ locale, namespace: "AboutPage.faq" });
   const keywords = tFaq
     .raw("questions")
     .map((key: { title: string }) => key.title);
@@ -74,6 +75,7 @@ export default async function page({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
+  // NOTE: do not remove it, it is a double check to ensure SSG is enabled
   setRequestLocale(locale);
 
   const t = await getTranslations("AboutPage");

--- a/app/[locale]/(client)/(pages)/blog-posts/[slug]/page.tsx
+++ b/app/[locale]/(client)/(pages)/blog-posts/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { notFound } from "next/navigation";
 import { OgImageType } from "@/types/types";
 import { Metadata } from "next";
 import { PAGES_ROUTES } from "@/constants/config";
-import { getTranslations, setRequestLocale } from "next-intl/server";
+import { setRequestLocale } from "next-intl/server";
 import { returnAlternateLanguages, returnCanonical } from "@/lib/utils";
 import { Typography } from "@/components/custom/typography";
 
@@ -62,10 +62,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const pagePath = PREVIEW + "/" + slug;
   const canonical = returnCanonical(locale, pagePath);
 
-  const t = await getTranslations({ locale, namespace: "SiteConfig" });
-  const SITE_NAME = t("name");
-  const SITE_COUNTRY = t("country");
-
   return {
     title: blogPostData.title,
     description: blogPostData.meta.description || blogPostData.excerpt,
@@ -79,13 +75,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       images: blogPostImageMetadata,
       title: blogPostData.title,
       description: blogPostData.meta.description || blogPostData.excerpt,
-      siteName: SITE_NAME,
       url: canonical,
-      countryName: SITE_COUNTRY,
       publishedTime: String(blogPostData.createdAt),
       modifiedTime: String(blogPostData.updatedAt),
       tags: blogPostData.meta.keywords,
-      authors: SITE_NAME,
     },
     twitter: {
       images: blogPostImageMetadata,
@@ -102,6 +95,7 @@ export default async function page({
   params: Promise<{ slug: string; locale: string }>;
 }) {
   const { slug, locale } = await params;
+  // NOTE: do not remove it, it is a double check to ensure SSG is enabled
   setRequestLocale(locale);
 
   const blogPost = await getBlogPost(slug);

--- a/app/[locale]/(client)/(pages)/contact/page.tsx
+++ b/app/[locale]/(client)/(pages)/contact/page.tsx
@@ -62,6 +62,7 @@ export default async function page({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
+  // NOTE: do not remove it, it is a double check to ensure SSG is enabled
   setRequestLocale(locale);
 
   const t = await getTranslations("ContactPage");

--- a/app/[locale]/(client)/(pages)/properties/[slug]/layout.tsx
+++ b/app/[locale]/(client)/(pages)/properties/[slug]/layout.tsx
@@ -9,7 +9,6 @@ export default async function layout({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  // NOTE: do not remove it, it is a double check to ensure SSG is enabled
   setRequestLocale(locale);
-  return <div className="max-w-[900px] mx-auto">{children}</div>;
+  return children;
 }

--- a/app/[locale]/(client)/(pages)/properties/[slug]/page.tsx
+++ b/app/[locale]/(client)/(pages)/properties/[slug]/page.tsx
@@ -66,9 +66,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const pagePath = PREVIEW + "/" + slug;
   const canonical = returnCanonical(locale, pagePath);
 
-  const t = await getTranslations({locale, namespace: "SiteConfig"});
-  const SITE_NAME = t("name");
-  const SITE_COUNTRY = t("country");
 
   return {
     title: property.data.title,
@@ -82,10 +79,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: property.data.title,
       description: property.data.description,
       url: canonical,
-      siteName: SITE_NAME,
-      countryName: SITE_COUNTRY,
       type: "article",
-      authors: SITE_NAME,
     },
     twitter: {
       images: propertyImagesMetadata,
@@ -98,6 +92,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function Page({ params }: Props) {
   const { slug, locale } = await params;
+  // NOTE: do not remove it, it is a double check to ensure SSG is enabled
   setRequestLocale(locale);
 
   const property = await getProperty(slug);

--- a/app/[locale]/(client)/layout.tsx
+++ b/app/[locale]/(client)/layout.tsx
@@ -19,7 +19,8 @@ export default async function layout({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  setRequestLocale(locale);
+  // TEMPORARY: Uncomment this if test did not work
+  // setRequestLocale(locale);
   const [logo, logoDark] = await Promise.all([
     getSiteInfoImage("logo", "theme_default"),
     getSiteInfoImage("logo", "theme_dark"),

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata({
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const locale = (await params).locale;
-  const t = await getTranslations("SiteConfig");
+  const t = await getTranslations({locale, namespace: "SiteConfig"});
   const metadataBase = new URL(process.env.NEXT_PUBLIC_FRONTEND_URL as string);
   const getFavicon = await getSiteInfoImage("icon", "theme_default");
   const faviconUrl = getFavicon?.url;
@@ -101,7 +101,8 @@ export default async function RootLayout({ children, params }: Props) {
     notFound();
   }
 
-  setRequestLocale(locale);
+  // TEMPORARY: Uncomment this if test did not work
+  // setRequestLocale(locale);
 
   // Import messages directly based on locale to avoid race conditions during parallel SSG
   const messages = (await import(`@/messages/${locale}.json`)).default;


### PR DESCRIPTION
- use explicit locale in generateMetadata function

- add setRequestLocale(locale) to pahts that must be SSG

- remove unimportant next-intl SSG config


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale configuration handling across pages to ensure consistent translation behavior.

* **Improvements**
  * Refined internationalization (i18n) setup with explicit locale scoping for translation lookups.
  * Simplified Open Graph metadata by removing redundant site configuration fields.

* **Chores**
  * Removed debug logging statements.
  * Code cleanup and formatting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->